### PR TITLE
Remove try/catch

### DIFF
--- a/cljs-lambda/src/cljs_lambda/util.cljs
+++ b/cljs-lambda/src/cljs_lambda/util.cljs
@@ -35,11 +35,7 @@
   (wrap-lambda-fn
    (fn [event context]
      (go
-       (let [result
-             (try
-               (<! (f event context))
-               (catch js/Error e
-                 e))]
+       (let [result (<! (f event context))]
          (if (instance? js/Error result)
            (fail!    context result)
            (succeed! context result)))))))


### PR DESCRIPTION
Catching errors from async processes doesn't work; the code that
throws runs outside of the context of the try/catch block.
