### PR TITLE
Updated gitignore to ignore node_modules

### DIFF
--- a/template/src/leiningen/new/cljs_lambda/gitignore
+++ b/template/src/leiningen/new/cljs_lambda/gitignore
@@ -5,3 +5,4 @@ pom.xml
 /out/
 /target/
 .lein*
+/node_modules


### PR DESCRIPTION
Since `lein-npm` is included in `project.clj` `node_modules` should probably be ignored.
