### PR TITLE
0.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ pom.xml.asc
 node_modules
 .hg/
 out
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cljs-lambda
 
+[![Build Status](https://travis-ci.org/nervous-systems/cljs-lambda.svg?branch=master)](https://travis-ci.org/nervous-systems/cljs-lambda)
+
 [AWS Lambda](http://aws.amazon.com/documentation/lambda/) is a service which
 allows named functions to be directly invoked (via a client API), have their
 execution triggered by a variety of AWS events (S3 upload, DynamoDB activity,
@@ -34,6 +36,17 @@ pieces of infrastructure.  While efforts are made to ensure backward
 compatibility in the Leiningen plugin, the `cljs-lambda` API is subject to
 breaking changes.
 
+# Coordinates
+
+## [Plugin](https://github.com/nervous-systems/cljs-lambda/tree/master/plugin)
+
+[![Clojars
+Project](http://clojars.org/io.nervous/lein-cljs-lambda/latest-version.svg)](http://clojars.org/io.nervous/lein-cljs-lambda)
+
+## [Library](https://github.com/nervous-systems/cljs-lambda/tree/master/cljs-lambda)
+
+[![Clojars Project](http://clojars.org/io.nervous/cljs-lambda/latest-version.svg)](http://clojars.org/io.nervous/cljs-lambda)
+
 # Get Started
 
 ```sh
@@ -57,17 +70,6 @@ $ lein cljs-lambda update-config work-magic :memory-size 256 :timeout 66
 
 ## Other
 - [Example project](https://github.com/nervous-systems/cljs-lambda/tree/master/example/) (generated from template)
-
-# Coordinates
-
-## [Plugin](https://github.com/nervous-systems/cljs-lambda/tree/master/plugin)
-
-[![Clojars
-Project](http://clojars.org/io.nervous/lein-cljs-lambda/latest-version.svg)](http://clojars.org/io.nervous/lein-cljs-lambda)
-
-## [Library](https://github.com/nervous-systems/cljs-lambda/tree/master/cljs-lambda)
-
-[![Clojars Project](http://clojars.org/io.nervous/cljs-lambda/latest-version.svg)](http://clojars.org/io.nervous/cljs-lambda)
 
 # Function Examples
 

--- a/cljs-lambda/project.clj
+++ b/cljs-lambda/project.clj
@@ -1,12 +1,13 @@
-(defproject io.nervous/cljs-lambda "0.3.0-SNAPSHOT"
+(defproject io.nervous/cljs-lambda "0.3.0"
   :description "Clojurescript AWS Lambda utilities"
   :url "https://github.com/nervous-systems/cljs-lambda"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}
   :scm {:name "git" :url "https://github.com/nervous-systems/cljs-lambda"}
-  :dependencies [[org.clojure/clojure       "1.7.0"]
-                 [org.clojure/clojurescript "1.7.228"]
+  :dependencies [[org.clojure/clojure       "1.8.0"]
+                 [org.clojure/clojurescript "1.8.34"]
                  [org.clojure/core.async    "0.2.374"]
-                 [funcool/promesa           "0.8.1"]]
+                 [org.clojure/tools.macro   "0.1.2"]
+                 [funcool/promesa           "1.1.1"]]
   :plugins [[lein-doo       "0.1.7-SNAPSHOT"]
             [lein-npm       "0.6.0"]
             [lein-cljsbuild "1.1.2"]
@@ -29,11 +30,9 @@
                 cljs-lambda.context]
    :metadata {:doc/format :markdown}
    :language :clojurescript
-   :html
-   {:transforms
-    ~(read-string (slurp "codox-transforms.edn"))}
+   :html     {:transforms ~(read-string (slurp "codox-transforms.edn"))}
    :source-uri
    ~(str "https://github.com/nervous-systems/cljs-lambda/"
-         "blob/v{version}/{filepath}#L{line}")}
+         "blob/master/cljs-lambda/{filepath}#L{line}")}
   :auto {"codox" {:file-pattern #"\.(clj[cs]?|md)$"
                   :paths ["doc" "src"]}})

--- a/cljs-lambda/src/cljs_lambda/context.cljs
+++ b/cljs-lambda/src/cljs_lambda/context.cljs
@@ -7,7 +7,7 @@
 * `:client-context`
 * `:log-group-name`
 * `:log-stream-name`
-* `:function-name`" )
+* `:function-name`")
 
 (defprotocol ContextHandle
   (-done!
@@ -16,7 +16,7 @@
   (msecs-remaining
    [this]
    "The number of milliseconds remaining until the timeout of the invocation
-   associated with this context." ))
+   associated with this context."))
 
 (defrecord ^:no-doc LambdaContext [js-handle]
   ContextHandle
@@ -36,6 +36,7 @@
 ```"
   [ctx & [err result]]
   (-done! ctx (clj->js err) (clj->js result)))
+
 (defn fail!
   "Trivial wrapper around [[done!]]
 
@@ -49,6 +50,7 @@
 ```"
   [ctx & [err]]
   (done! ctx err nil))
+
 (defn succeed!
   "Trivial wrapper around [[done!]]
 

--- a/cljs-lambda/src/cljs_lambda/local.cljs
+++ b/cljs-lambda/src/cljs_lambda/local.cljs
@@ -10,7 +10,9 @@
 (defrecord ^:no-doc LocalContext [result-channel]
   ctx/ContextHandle
   (-done! [this err result]
-    (async/put! result-channel [(js->clj err) (js->clj result)]))
+    (async/put!
+     result-channel [(js->clj err    :keywordize-keys true)
+                     (js->clj result :keywordize-keys true)]))
   (msecs-remaining [this]
     -1))
 

--- a/cljs-lambda/src/cljs_lambda/macros.cljc
+++ b/cljs-lambda/src/cljs_lambda/macros.cljc
@@ -1,5 +1,6 @@
 (ns cljs-lambda.macros
-  #? (:cljs (:require [cljs-lambda.util]))
+  (:require #? (:clj  [clojure.tools.macro :as macro]
+                :cljs [cljs-lambda.util]))
   #? (:cljs (:require-macros [cljs-lambda.macros])))
 
 #? (:clj
@@ -21,8 +22,9 @@
    (fn [{n :msecs} ctx]
      ...)))
 ```"
-      [name bindings & body]
-      `(def ~(vary-meta name assoc :export true)
-         (cljs-lambda.util/async-lambda-fn
-          (fn ~bindings
-            ~@body)))))
+      [name & body]
+      (let [[name [bindings & body]] (macro/name-with-attributes name body)]
+       `(def ~(vary-meta name assoc :export true)
+          (cljs-lambda.util/async-lambda-fn
+           (fn ~bindings
+             ~@body))))))

--- a/cljs-lambda/test/cljs_lambda/test/util.cljs
+++ b/cljs-lambda/test/cljs_lambda/test/util.cljs
@@ -65,8 +65,8 @@
   (let [error (js/Error. "12 eggs")
         f     (lambda/async-lambda-fn
                (fn [_ ctx]
-                 (js/Promise.
-                  (fn [resolve reject]
+                 (p/promise
+                  (fn [_ _]
                     (js/setTimeout #(ctx/fail! ctx error) 50)))))]
     (catches
      (invoke f)

--- a/example/project.clj
+++ b/example/project.clj
@@ -2,15 +2,15 @@
   :description "FIXME"
   :url "http://please.FIXME"
   :dependencies [[org.clojure/clojure            "1.8.0"]
-                 [org.clojure/clojurescript      "1.7.228"]
+                 [org.clojure/clojurescript      "1.8.34"]
                  [org.clojure/core.async         "0.2.374"]
 
-                 [io.nervous/cljs-lambda         "0.3.0-SNAPSHOT"]
+                 [io.nervous/cljs-lambda         "0.3.0"]
                  [io.nervous/cljs-nodejs-externs "0.2.0"]]
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-npm       "0.6.0"]
             [lein-doo       "0.1.7-SNAPSHOT"]
-            [io.nervous/lein-cljs-lambda "0.5.1-SNAPSHOT"]]
+            [io.nervous/lein-cljs-lambda "0.5.1"]]
   :npm {:dependencies [[source-map-support "0.4.0"]]}
   :source-paths ["src"]
   :cljs-lambda

--- a/example/test/example/core_test.cljs
+++ b/example/test/example/core_test.cljs
@@ -2,7 +2,7 @@
   (:require [example.core :refer [work-magic config]]
             [cljs.test :refer-macros [deftest is]]
             [cljs-lambda.local :refer [invoke channel]]
-            [promesa.core :as p :refer-macros [alet]]
+            [promesa.core :as p :refer [await] :refer-macros [alet]]
             [cljs.core.async :refer [<!]])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
@@ -10,9 +10,7 @@
   (cljs.test/async
    done
    (-> p
-       (p/catch (fn [e]
-                  (println (.. e -stack))
-                  (is (not e))))
+       (p/catch #(is (not %)))
        (p/then done))))
 
 (defn with-some-error [p]
@@ -20,7 +18,7 @@
     #(is false "Expected error")
     (constantly nil)))
 
-(deftest wrong-word
+(deftest echo
   (-> (invoke work-magic {:magic-word "not the magic word"})
       with-some-error
       with-promised-completion))
@@ -31,8 +29,9 @@
    :msecs 2})
 
 (deftest delay-channel-spell
-  (-> (invoke work-magic delay-channel-req)
-      (p/then #(is (= % {"waited" 2})))))
+  (with-promised-completion
+    (alet [{:keys [waited]} (await (invoke work-magic delay-channel-req))]
+      (is (= waited 2)))))
 
 (deftest delay-channel-spell-go
   (cljs.test/async
@@ -40,7 +39,7 @@
    (go
      (let [[tag response] (<! (channel work-magic delay-channel-req))]
        (is (= tag :succeed))
-       (is (= response {"waited" 2})))
+       (is (= response {:waited 2})))
      (done))))
 
 (deftest delay-fail-spell

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject io.nervous/lein-cljs-lambda "0.5.1-SNAPSHOT"
+(defproject io.nervous/lein-cljs-lambda "0.5.1"
   :description "Deploying Clojurescript functions to AWS Lambda"
   :url "https://github.com/nervous-systems/cljs-lambda"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}

--- a/plugin/resources/index.mustache
+++ b/plugin/resources/index.mustache
@@ -4,7 +4,12 @@ try {
 } catch(err) {
 }
 {{/source-map}}
+
 require("./{{output-dir}}/goog/bootstrap/nodejs.js");
+
+// It's not clear why this is necessary
+goog.global.CLOSURE_UNCOMPILED_DEFINES = {"cljs.core._STAR_target_STAR_":"nodejs"};
+
 require("./{{output-to}}");
 
 {{#module}}

--- a/plugin/src/leiningen/cljs_lambda.clj
+++ b/plugin/src/leiningen/cljs_lambda.clj
@@ -49,9 +49,9 @@
         [build] (if-not cljs-build-id
                   builds
                   (filter #(= (:id %) cljs-build-id) builds))]
-    (if-not build
-      (leiningen.core.main/abort "Can't find cljsbuild build")
-      build)))
+    (cond (not build)   (leiningen.core.main/abort "Can't find cljsbuild build")
+          (build :main) (leiningen.core.main/abort "Can't deploy build w/ :main")
+          :else         build)))
 
 (def fn-keys
   #{:name :create :region :memory-size :role :invoke :description :timeout

--- a/template/project.clj
+++ b/template/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-lambda/lein-template "0.4.2-SNAPSHOT"
+(defproject cljs-lambda/lein-template "0.4.2"
   :description "Clojurescript on AWS Lambda"
   :url "https://github.com/nervous-systems/cljs-lambda"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}

--- a/template/src/leiningen/new/cljs_lambda/project.clj
+++ b/template/src/leiningen/new/cljs_lambda/project.clj
@@ -2,15 +2,15 @@
   :description "FIXME"
   :url "http://please.FIXME"
   :dependencies [[org.clojure/clojure            "1.8.0"]
-                 [org.clojure/clojurescript      "1.7.228"]
+                 [org.clojure/clojurescript      "1.8.34"]
                  [org.clojure/core.async         "0.2.374"]
 
-                 [io.nervous/cljs-lambda         "0.3.0-SNAPSHOT"]
+                 [io.nervous/cljs-lambda         "0.3.0"]
                  [io.nervous/cljs-nodejs-externs "0.2.0"]]
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-npm       "0.6.0"]
             [lein-doo       "0.1.7-SNAPSHOT"]
-            [io.nervous/lein-cljs-lambda "0.5.1-SNAPSHOT"]]
+            [io.nervous/lein-cljs-lambda "0.5.1"]]
   :npm {:dependencies [[source-map-support "0.4.0"]]}
   :source-paths ["src"]
   :cljs-lambda


### PR DESCRIPTION
- Ensure :target is :nodejs for :optimizations :none
- Update promesa, Clojurescript, Clojure deps
- Update type-checking in cljs-lambda (now that promesa doesn't install js/Promise)
