### PR TITLE
Allow Lambda runtime environment to inherit compile/deploy-time environment variables

### DIFF
--- a/cljs-lambda/doc/testing.md
+++ b/cljs-lambda/doc/testing.md
@@ -2,8 +2,8 @@
 
 While it's strongly suggested that Lambda functions are minimal abstractions of
 the execution environment (i.e. input/output processing only, delegating to
-naive Clojurescript functions), there are times when it's going to make sense to
-test the entry points off of EC2.
+generic Clojurescript functions), there are times when it's going to make sense
+to test the entry points off of EC2.
 
 [[cljs-lambda.local/invoke]] invokes a Lambda handler with the supplied event
 (optional, nil), supplying a context suitable for local evaluation.  The context
@@ -30,7 +30,7 @@ or `:fail`.
 ### Example
 
 ```clojure
-(def fs (.promisifyAll js/Promise (nodejs/require "fs")))
+(def fs (.promisifyAll promesa/Promise (nodejs/require "fs")))
 
 (deflambda read-file [path ctx]
   (.readFileAsync fs path))
@@ -45,8 +45,23 @@ or `:fail`.
   (str "Hi " caller-name " I'm " my-name))
 
 ;; The default context values aren't particularly exciting
-(invoke read-file "Mary") => ;; <Promise "Hi Mary, I'm functionName">
+(invoke identify "Mary") => ;; <Promise "Hi Mary, I'm functionName">
 ;; But custom values may be supplied
-(invoke read-file "Mary" (->context {:function-name "identify"}))
+(invoke identify "Mary" (->context {:function-name "identify"}))
 ;; => ;; <Promise "Hi Mary, I'm identify">
 ```
+
+## Environment Variables
+
+When testing functions which retrieve environment variables via
+[[cljs-lambda.context/env]], alternate values may be supplied in a test's
+context object.
+
+```clojure
+(deflambda env [k ctx]
+  (ctx/env ctx k))
+
+(invoke read-file "USER" (->context {:env {"USER" "moe"}}))
+```
+
+When deployed, `ctx/env` would read the value from Node's `process.env`.

--- a/cljs-lambda/project.clj
+++ b/cljs-lambda/project.clj
@@ -1,13 +1,14 @@
-(defproject io.nervous/cljs-lambda "0.3.0"
+(defproject io.nervous/cljs-lambda "0.3.1-SNAPSHOT"
   :description "Clojurescript AWS Lambda utilities"
   :url "https://github.com/nervous-systems/cljs-lambda"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}
   :scm {:name "git" :url "https://github.com/nervous-systems/cljs-lambda"}
-  :dependencies [[org.clojure/clojure       "1.8.0"]
-                 [org.clojure/clojurescript "1.8.34"]
-                 [org.clojure/core.async    "0.2.374"]
-                 [org.clojure/tools.macro   "0.1.2"]
-                 [funcool/promesa           "1.1.1"]]
+  :dependencies [[org.clojure/clojure            "1.8.0"]
+                 [org.clojure/clojurescript      "1.8.34"]
+                 [org.clojure/core.async         "0.2.374"]
+                 [org.clojure/tools.macro        "0.1.2"]
+                 [funcool/promesa                "1.1.1"]
+                 [io.nervous/cljs-nodejs-externs "0.2.0"]]
   :plugins [[lein-doo       "0.1.7-SNAPSHOT"]
             [lein-npm       "0.6.0"]
             [lein-cljsbuild "1.1.2"]
@@ -17,11 +18,11 @@
   :cljsbuild
   {:builds [{:id "test"
              :source-paths ["src" "test"]
-             :compiler {:output-to  "target/test/cljs-lambda.js"
-                        :output-dir "target/test"
-                        :target :nodejs
+             :compiler {:output-to     "target/test/cljs-lambda.js"
+                        :output-dir    "target/test"
+                        :target        :nodejs
                         :optimizations :none
-                        :main cljs-lambda.test.runner}}]}
+                        :main          cljs-lambda.test.runner}}]}
   :codox
   {:source-paths ["src"]
    :namespaces [cljs-lambda.util

--- a/cljs-lambda/src/cljs_lambda/context.cljs
+++ b/cljs-lambda/src/cljs_lambda/context.cljs
@@ -16,14 +16,30 @@
   (msecs-remaining
    [this]
    "The number of milliseconds remaining until the timeout of the invocation
-   associated with this context."))
+   associated with this context.")
+  (environment
+   [this]
+   "Retrieve a map of environment variables."))
 
 (defrecord ^:no-doc LambdaContext [js-handle]
   ContextHandle
   (-done! [this err result]
     (.done js-handle err result))
   (msecs-remaining [this]
-    (.getRemainingTimeInMillis js-handle)))
+    (.getRemainingTimeInMillis js-handle))
+  (environment [this]
+    (js->clj (.. js/process -env))))
+
+(defn env
+  "Retrieve an environment variable by name, defaulting to `nil` if not found.
+
+```clojure
+(env ctx \"USER\")
+(env ctx :USER)
+(env ctx 'USER)
+```"
+  [ctx k]
+  (get (environment ctx) (name k)))
 
 (defn done!
   "Terminate execution of the handler associated w/ the given context, conveying

--- a/cljs-lambda/test/cljs_lambda/test/util.cljs
+++ b/cljs-lambda/test/cljs_lambda/test/util.cljs
@@ -1,6 +1,6 @@
 (ns cljs-lambda.test.util
   (:require [cljs-lambda.util :as lambda]
-            [cljs-lambda.local :refer [invoke]]
+            [cljs-lambda.local :as local :refer [invoke]]
             [cljs-lambda.context :as ctx]
             [cljs.test :refer-macros [deftest is]]
             [promesa.core :as p])
@@ -135,3 +135,11 @@
              (ctx/msecs-remaining ctx)))]
     (p/then (invoke f)
       (will= -1))))
+
+(deftest-async env
+  (let [f   (lambda/async-lambda-fn
+             (fn [_ ctx]
+               (ctx/env ctx :ENV_VAR)))
+        ctx (local/->context {:env {'ENV_VAR "deftest-async env"}})]
+    (p/then (invoke f nil ctx)
+      (will= "deftest-async env"))))

--- a/example/project.clj
+++ b/example/project.clj
@@ -1,20 +1,20 @@
 (defproject example "0.1.0-SNAPSHOT"
   :description "FIXME"
   :url "http://please.FIXME"
-  :dependencies [[org.clojure/clojure            "1.8.0"]
-                 [org.clojure/clojurescript      "1.8.34"]
-                 [org.clojure/core.async         "0.2.374"]
-
-                 [io.nervous/cljs-lambda         "0.3.0"]
-                 [io.nervous/cljs-nodejs-externs "0.2.0"]]
+  :dependencies [[org.clojure/clojure       "1.8.0"]
+                 [org.clojure/clojurescript "1.8.34"]
+                 [org.clojure/core.async    "0.2.374"]
+                 [io.nervous/cljs-lambda    "0.3.1-SNAPSHOT"]]
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-npm       "0.6.0"]
             [lein-doo       "0.1.7-SNAPSHOT"]
-            [io.nervous/lein-cljs-lambda "0.5.1"]]
+            [io.nervous/lein-cljs-lambda "0.5.2-SNAPSHOT"]]
   :npm {:dependencies [[source-map-support "0.4.0"]]}
   :source-paths ["src"]
   :cljs-lambda
-  {:defaults      {:role "FIXME"}
+  {:env {:set     {"CLJS_LAMBDA_EXAMPLE" "Yes"}
+         :capture #{"USER" #"^TEST_"}}
+   :defaults      {:role "FIXME"}
    :resource-dirs ["static"]
    :functions
    [{:name   "work-magic"

--- a/example/src/example/core.cljs
+++ b/example/src/example/core.cljs
@@ -8,9 +8,6 @@
             [promesa.core :as p])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-;; For optimizations :advanced
-(set! *main-cli-fn* identity)
-
 (def config
   (-> (nodejs/require "fs")
       (.readFileSync "static/config.edn" "UTF-8")
@@ -42,4 +39,6 @@
 (deflambda work-magic [{:keys [magic-word] :as input} context]
   (when (not= magic-word (config :magic-word))
     (throw (js/Error. "Your magic word is garbage")))
-  (cast-async-spell input context))
+  (if (= (input :spell) "echo-env")
+    (ctx/environment ctx)
+    (cast-async-spell input context)))

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject io.nervous/lein-cljs-lambda "0.5.1"
+(defproject io.nervous/lein-cljs-lambda "0.5.2-SNAPSHOT"
   :description "Deploying Clojurescript functions to AWS Lambda"
   :url "https://github.com/nervous-systems/cljs-lambda"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}

--- a/plugin/resources/index-advanced.mustache
+++ b/plugin/resources/index-advanced.mustache
@@ -5,6 +5,10 @@ try {
 }
 {{/source-map}}
 
+{{#env}}
+process.env.{{key}} = "{{value}}";
+{{/#env}}
+
 require("./{{output-to}}");
 
 {{#module}}

--- a/plugin/resources/index.mustache
+++ b/plugin/resources/index.mustache
@@ -5,6 +5,10 @@ try {
 }
 {{/source-map}}
 
+{{#env}}
+process.env.{{key}} = "{{value}}";
+{{/#env}}
+
 require("./{{output-dir}}/goog/bootstrap/nodejs.js");
 
 // It's not clear why this is necessary

--- a/template/project.clj
+++ b/template/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-lambda/lein-template "0.4.2"
+(defproject cljs-lambda/lein-template "0.4.3-SNAPSHOT"
   :description "Clojurescript on AWS Lambda"
   :url "https://github.com/nervous-systems/cljs-lambda"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}

--- a/template/src/leiningen/new/cljs_lambda/core.cljs
+++ b/template/src/leiningen/new/cljs_lambda/core.cljs
@@ -8,9 +8,6 @@
             [promesa.core :as p])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-;; For optimizations :advanced
-(set! *main-cli-fn* identity)
-
 (def config
   (-> (nodejs/require "fs")
       (.readFileSync "static/config.edn" "UTF-8")
@@ -42,4 +39,6 @@
 (deflambda work-magic [{:keys [magic-word] :as input} context]
   (when (not= magic-word (config :magic-word))
     (throw (js/Error. "Your magic word is garbage")))
-  (cast-async-spell input context))
+  (if (= (input :spell) "echo-env")
+    (ctx/environment ctx)
+    (cast-async-spell input context)))

--- a/template/src/leiningen/new/cljs_lambda/project.clj
+++ b/template/src/leiningen/new/cljs_lambda/project.clj
@@ -1,20 +1,20 @@
 (defproject {{name}} "0.1.0-SNAPSHOT"
   :description "FIXME"
   :url "http://please.FIXME"
-  :dependencies [[org.clojure/clojure            "1.8.0"]
-                 [org.clojure/clojurescript      "1.8.34"]
-                 [org.clojure/core.async         "0.2.374"]
-
-                 [io.nervous/cljs-lambda         "0.3.0"]
-                 [io.nervous/cljs-nodejs-externs "0.2.0"]]
+  :dependencies [[org.clojure/clojure       "1.8.0"]
+                 [org.clojure/clojurescript "1.8.34"]
+                 [org.clojure/core.async    "0.2.374"]
+                 [io.nervous/cljs-lambda    "0.3.1-SNAPSHOT"]]
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-npm       "0.6.0"]
             [lein-doo       "0.1.7-SNAPSHOT"]
-            [io.nervous/lein-cljs-lambda "0.5.1"]]
+            [io.nervous/lein-cljs-lambda "0.5.2-SNAPSHOT"]]
   :npm {:dependencies [[source-map-support "0.4.0"]]}
   :source-paths ["src"]
   :cljs-lambda
-  {:defaults      {:role "FIXME"}
+  {:env {:set     {"CLJS_LAMBDA_EXAMPLE" "Yes"}
+         :capture #{"USER" #"^TEST_"}}
+   :defaults      {:role "FIXME"}
    :resource-dirs ["static"]
    :functions
    [{:name   "work-magic"


### PR DESCRIPTION
Provide `context/env` for retrieval, and add facility for providing values per invocation, in tests, so that nobody has to fuck w/ process.env. 
