### PR TITLE
Preserve file permissions in the zip

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -6,6 +6,7 @@
                  [lein-npm       "0.5.0"]
                  [base64-clj     "0.1.1"]
                  [de.ubercode.clostache/clostache "1.4.0"]
+                 [org.apache.commons/commons-compress "1.11"]
                  [camel-snake-kebab "0.3.2"]]
   :exclusions [org.clojure/clojure]
   :eval-in-leiningen true)

--- a/plugin/src/leiningen/cljs_lambda/zip_tedium.clj
+++ b/plugin/src/leiningen/cljs_lambda/zip_tedium.clj
@@ -2,12 +2,32 @@
   (:require [leiningen.cljs-lambda.logging :refer [log]]
             [clojure.java.io :as io])
   (:import [java.io File]
-           [java.util.zip ZipEntry ZipOutputStream]))
+           [java.nio.file Files LinkOption]
+           [java.nio.file.attribute PosixFilePermission]
+           [org.apache.commons.compress.archivers.zip ZipArchiveEntry
+                                                      ZipArchiveOutputStream]))
+
+(defn- get-posix-mode [file]
+  (let [no-follow (into-array [LinkOption/NOFOLLOW_LINKS])
+        perms (Files/getPosixFilePermissions (.toPath file) no-follow)]
+    (cond-> 0
+      (contains? perms PosixFilePermission/OWNER_READ)     (bit-set 8)
+      (contains? perms PosixFilePermission/OWNER_WRITE)    (bit-set 7)
+      (contains? perms PosixFilePermission/OWNER_EXECUTE)  (bit-set 6)
+      (contains? perms PosixFilePermission/GROUP_READ)     (bit-set 5)
+      (contains? perms PosixFilePermission/GROUP_WRITE)    (bit-set 4)
+      (contains? perms PosixFilePermission/GROUP_EXECUTE)  (bit-set 3)
+      (contains? perms PosixFilePermission/OTHERS_READ)    (bit-set 2)
+      (contains? perms PosixFilePermission/OTHERS_WRITE)   (bit-set 1)
+      (contains? perms PosixFilePermission/OTHERS_EXECUTE) (bit-set 0))))
 
 (defn- zip-entry [zip-stream file & [path]]
-  (.putNextEntry zip-stream (ZipEntry. (or path (.getPath file))))
-  (io/copy file zip-stream)
-  (.closeEntry zip-stream))
+  (let [path  (or path (.getPath file))
+        entry (ZipArchiveEntry. file path)]
+    (.setUnixMode entry (get-posix-mode file))
+    (.putArchiveEntry zip-stream entry)
+    (io/copy file zip-stream)
+    (.closeArchiveEntry zip-stream)))
 
 (defn extension [file]
   (let [path (.getPath file)]
@@ -47,7 +67,7 @@
         path (.getAbsolutePath zip-file)]
     (log :verbose "Writing zip to" path)
     (.delete zip-file)
-    (let [zip-stream (ZipOutputStream. (io/output-stream zip-file))]
+    (let [zip-stream (ZipArchiveOutputStream. zip-file)]
       (stuff-zip zip-stream compiler-opts spec)
       (doseq [d resource-dirs]
         (zip-resources zip-stream (io/file d)))


### PR DESCRIPTION
AWS Lambda [allows running arbitrary executables](https://aws.amazon.com/blogs/compute/running-executables-in-aws-lambda/) by packaging them with the function.

`java.util.zip` does not preserve file permissions inside the archive, so these binaries end up without the "x" permission, so function can't run them (fails with something like "spawn EACCES").

This uses Apache commons-compress for creating zip archive and setting permissions properly.

Here is one of the threads describing a problem in more detail https://github.com/binoculars/aws-lambda-ffmpeg/issues/13 (not cljs-lambda related, but still the same problem)
