### PR TITLE
Default the runtime to "nodejs4.3", which is now supported by AWS

### DIFF
--- a/plugin/src/leiningen/cljs_lambda.clj
+++ b/plugin/src/leiningen/cljs_lambda.clj
@@ -57,7 +57,7 @@
 
 (def fn-keys
   #{:name :create :region :memory-size :role :invoke :description :timeout
-    :publish :alias})
+    :publish :alias :runtime})
 
 (defn- augment-fn [{:keys [defaults]} cli-kws fn-spec]
   (merge default-defaults

--- a/plugin/src/leiningen/cljs_lambda/aws.clj
+++ b/plugin/src/leiningen/cljs_lambda/aws.clj
@@ -67,10 +67,11 @@
     nil
     {:preserve-names? true})))
 
+(def default-runtime "nodejs4.3")
+
 (defn- create-function! [fn-spec zip-path]
-  (let [args (-> fn-spec
-                 (assoc :runtime "nodejs" :zip-file zip-path)
-                 fn-spec->cli-args)]
+  (let [args (fn-spec->cli-args
+              (merge {:runtime default-runtime} fn-spec {:zip-file zip-path}))]
     (-> (lambda-cli! :create-function args) :out str/trim)))
 
 (defn- update-function-config! [fn-spec]


### PR DESCRIPTION
Can be overridden by supplying e.g. `:runtime :node` for a fn in the project file, or on the command line.
