### PR TITLE
:dead-letter configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 node_modules
 .hg/
 out
+.idea
+*.iml

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -61,6 +61,7 @@ invoked.  An example:
  :timeout 3 ;; seconds
  :memory-size 128 ;; MB
  :vpc { :subnets [] :security-groups [] }
+ :dead-letter "arn:..."
 ```
 
 The wiki's [plugin


### PR DESCRIPTION
Looks awkward, but there's _issue_ with remote configuration when compared to VPC.

* If there's no VPC set, remote config contains it (empty sequences)
* But if there's no DLC set, remote config doesn't contain it

Thus, quite a lot of merge of `fn-spec-defaults` just to be able to compare local and remote configs.

Part of #56.