### PR TITLE
:env support

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -62,7 +62,11 @@ invoked.  An example:
  :memory-size 128 ;; MB
  :vpc { :subnets [] :security-groups [] }
  :dead-letter "arn:..."
+ :env {"VAR_A" "VALUE_A"
+       "VAR_B" "VALUE_B"}
 ```
+
+**NOTE:** Environment variables are case sensitive. You can provide `VAR_A` and `VAR_a`. Just be careful.
 
 The wiki's [plugin
 reference](https://github.com/nervous-systems/cljs-lambda/wiki/Plugin-Reference)

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -6,7 +6,6 @@
                  [lein-npm       "0.6.2"]
                  [base64-clj     "0.1.1"]
                  [de.ubercode.clostache/clostache "1.4.0"]
-                 [org.apache.commons/commons-compress "1.11"]
-                 [camel-snake-kebab "0.3.2"]]
+                 [org.apache.commons/commons-compress "1.11"]]
   :exclusions [org.clojure/clojure]
   :eval-in-leiningen true)

--- a/plugin/src/leiningen/cljs_lambda/aws.clj
+++ b/plugin/src/leiningen/cljs_lambda/aws.clj
@@ -171,8 +171,8 @@
       (if-let [vpc (:vpc remote)]
         (assoc remote :vpc
           (-> vpc
-              (select-keys #{:SubnetIds :SecurityGroupIds})
-              (set/rename-keys {:SubnetIds :subnets :SecurityGroupIds :security-groups}))))
+              (select-keys #{"SubnetIds" "SecurityGroupIds"})
+              (set/rename-keys {"SubnetIds" :subnets "SecurityGroupIds" :security-groups}))))
       {:dead-letter (get-in remote [:dead-letter "TargetArn"] "")}
       {:env (-> (get-in remote [:env "Variables"] {}))})))
 

--- a/plugin/src/leiningen/cljs_lambda/aws.clj
+++ b/plugin/src/leiningen/cljs_lambda/aws.clj
@@ -44,7 +44,7 @@
     (string/join
       ","
       (for [[k v] v]
-        (str k "=" v)))
+        (str (name k) "=" v)))
     "}"))
 
 (defmethod ->cli-arg-value :dead-letter-config [k v]

--- a/plugin/src/leiningen/cljs_lambda/aws.clj
+++ b/plugin/src/leiningen/cljs_lambda/aws.clj
@@ -90,21 +90,6 @@
 (def update-function-code-args
   (remove #{:vpc :dead-letter :env} create-function-args))
 
-(defn validate-fn-spec! [{fn-name :name vpc :vpc}]
-  (let [subnets (:subnets vpc)
-        security-groups (:security-groups vpc)
-        vpc-set (or (seq subnets) (seq security-groups))]
-    (when vpc-set
-      (when-not (and (> (count subnets) 0) (> (count security-groups) 0))
-        (leiningen.core.main/abort
-          "Invalid VPC spec for" fn-name "function. At least one subnet and one security group must be specified"))
-      (when-not (every? string? subnets)
-        (leiningen.core.main/abort
-          "Invalid VPC spec for" fn-name "function. Subnets not a list of strings:" subnets))
-      (when-not (every? string? security-groups)
-        (leiningen.core.main/abort
-          "Invalid VPC spec for" fn-name "function. Security groups not a list of strings:" security-groups)))))
-
 (defn fn-spec->cli-args [fn-args {:keys [publish] :as fn-spec}]
   (let [args (merge {:output "text" :query "Version"} fn-spec)]
     (-> args
@@ -199,7 +184,6 @@
 
 (defn- deploy-function!
   [zip-path {fn-name :name create? :create :as fn-spec}]
-  (validate-fn-spec! fn-spec)
   (if-let [remote-config (get-function-configuration! fn-spec)]
     (do
       (when-not (same-config? remote-config fn-spec)

--- a/plugin/src/leiningen/cljs_lambda/aws.clj
+++ b/plugin/src/leiningen/cljs_lambda/aws.clj
@@ -8,7 +8,6 @@
             [clojure.string :as str]
             [base64-clj.core :as base64]
             [clojure.pprint :as pprint]
-            [camel-snake-kebab.core :as csk]
             [clojure.string :as string])
   (:import [java.io File]
            [java.util.concurrent Executors]))

--- a/plugin/src/leiningen/cljs_lambda/aws.clj
+++ b/plugin/src/leiningen/cljs_lambda/aws.clj
@@ -48,7 +48,7 @@
     "}"))
 
 (defmethod ->cli-arg-value :dead-letter-config [k v]
-  (str "TargetArn=" (str v)))
+  (str "TargetArn=" v))
 
 (defmethod ->cli-arg-value :default [k v]
   (if (keyword? v) (name v) (str v)))

--- a/plugin/src/leiningen/cljs_lambda/aws.clj
+++ b/plugin/src/leiningen/cljs_lambda/aws.clj
@@ -152,7 +152,8 @@
 (defn normalize-config [config]
   (-> config
       (update-in [:vpc :subnets] sort)
-      (update-in [:vpc :security-groups] sort)))
+      (update-in [:vpc :security-groups] sort)
+      (update-in [:env] clojure.walk/stringify-keys)))
 
 (defn remote-config->local-config [remote]
   (let [remote (set/rename-keys remote {"FunctionName" :name


### PR DESCRIPTION
**What's done:**

* `->cli-arg-value` as multimethod
* `validate-fn-spec!` removed (VPC related), because it fails anyway if it's wrong
* had to remove camel-snake-kebab (function remote config, json parsing), because you can provide case sensitive env variables (see screenshot below) -> it cripples variable names -> disallows local remote config comparison

<img width="780" alt="screen shot 2017-02-19 at 21 58 28" src="https://cloud.githubusercontent.com/assets/1084172/23106500/a3b7be72-f6ee-11e6-82e1-2b74eb69b064.png">

**What's left:**

I left `:cljs-lambda :env` intact in this PR. This PR just adds support for `:env` in `:cljs-lambda :defaults` and in `:cljs-lambda :functions`. And now ...

* 0.6.5 can be released with `:cljs-lambda :env` and new `:env`, we're not going to break compatibility, they can coexist together for a while,
* 0.7 or 1.0 or ... can be the release where `:cljs-lambda :env` will be trashed
* or ...

Just let me know what do you think and what to do.

Part of #56.