### PR TITLE
fix: adds missing serverless-cljs-plugin dependency

### DIFF
--- a/templates/serverless/src/leiningen/new/serverless_cljs/project.clj
+++ b/templates/serverless/src/leiningen/new/serverless_cljs/project.clj
@@ -4,6 +4,7 @@
                  [io.nervous/cljs-lambda    "0.3.5"]]
   :plugins [[lein-npm                    "0.6.2"]
             [io.nervous/lein-cljs-lambda "0.6.5"]]
+  :npm {:dependencies [[serverless-cljs-plugin "0.1.2"]]}
   :cljs-lambda {:compiler
                 {:inputs  ["src"]
                  :options {:output-to     "target/{{name}}/{{sanitized}}.js"


### PR DESCRIPTION
Hello,
I find that without this fix (adding the npm module) the serverless-cljs lein template 
throws this error:
```
  Error --------------------------------------------------

     Cannot find module 'serverless-cljs-plugin'
...
```

steps to reproduce:
1. lein new serverless-cljs example && cd $_
2. lein deps
3. serverless deploy