### PR TITLE
Fix issues with :optimizations :advanced

### DIFF
--- a/plugin/resources/index-advanced.mustache
+++ b/plugin/resources/index-advanced.mustache
@@ -9,10 +9,10 @@ try {
 process.env.{{key}} = "{{value}}";
 {{/#env}}
 
-require("./{{output-to}}");
+var __CLJS_LAMBDA_NS_ROOT = require("./{{output-to}}");
 
 {{#module}}
 {{#function}}
-exports.{{export}} = {{js-name}};
+exports.{{export}} = __CLJS_LAMBDA_NS_ROOT.{{js-name}};
 {{/function}}
 {{/module}}

--- a/plugin/src/leiningen/cljs_lambda/zip_tedium.clj
+++ b/plugin/src/leiningen/cljs_lambda/zip_tedium.clj
@@ -55,17 +55,18 @@
         (when-not (.isDirectory file)
           (zip-entry zip-stream file path))))))
 
-(defmulti  stuff-zip (fn [_ {:keys [optimizations]} _] optimizations))
-
-(derive ::advanced ::single-file)
-(derive ::simple   ::single-file)
+(defmulti  stuff-zip
+  (fn [_ {:keys [optimizations]} _]
+    (if (#{:simple :advanced} optimizations)
+      :single-file
+      :default)))
 
 (defmethod stuff-zip :default [zip-stream {:keys [output-dir]} {:keys [index-path]}]
   (zip-entry zip-stream (io/file index-path) "index.js")
   (zip-below zip-stream (io/file output-dir))
   (zip-below zip-stream (io/file "node_modules")))
 
-(defmethod stuff-zip ::single-file [zip-stream {:keys [output-to source-map]} {:keys [index-path]}]
+(defmethod stuff-zip :single-file [zip-stream {:keys [output-to source-map]} {:keys [index-path]}]
   (zip-entry zip-stream (io/file index-path) "index.js")
   (zip-entry zip-stream (io/file output-to))
   (when (string? source-map)


### PR DESCRIPTION
This pull requests fixes two problems I found while using cljs-lambda with :optimizations :advanced.

Problem one is that the index.js generated for :advanced causes a ReferenceError. The fix consists in making index-advanced.mustache work exactly like index-simple.mustache (ie, not assuming that calling require() exports the required symbols in the global scope).

Problem two is that single-file packaging was broken in bd576790. The fix is pretty straightforward (there are a number of possible fixes, I went for what feels most obvious to me).