### PR TITLE
Fix ReferenceError exception by passing :output-wrapper true to the compiler

### DIFF
--- a/plugin/src/leiningen/cljs_lambda.clj
+++ b/plugin/src/leiningen/cljs_lambda.clj
@@ -59,7 +59,13 @@
 
 (defn- extract-compile-opts [proj]
   {:post [(or (nil? %) (and (coll? (:inputs %)) (map? (:options %))))]}
-  (some-> proj :cljs-lambda :compiler))
+  (some-> proj
+    :cljs-lambda
+    :compiler
+    (update :options (fn [{:keys [optimizations] :as options}]
+                       (if (= :advanced optimizations)
+                         (merge {:output-wrapper true} options)
+                         options)))))
 
 (def fn-keys
   #{:name :create :region :memory-size :role :invoke :description :timeout


### PR DESCRIPTION
When invoking the clojurescript compiler directly with `:optimizations :advanced`,
also set `:output-wrapper true`. lein-cljsbuild does this too, and without it
`^:export`ed symbols don't get exported correctly.

See #78.