### PR TITLE
Use AWS SDK, rather than CLI

### DIFF
--- a/example/project.clj
+++ b/example/project.clj
@@ -8,7 +8,7 @@
   :plugins [[lein-cljsbuild "1.1.4"]
             [lein-npm       "0.6.0"]
             [lein-doo       "0.1.7"]
-            [io.nervous/lein-cljs-lambda "0.6.6"]]
+            [io.nervous/lein-cljs-lambda "0.7.0-SNAPSHOT"]]
   :npm {:dependencies [[source-map-support "0.4.0"]]}
   :source-paths ["src"]
   :cljs-lambda

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject io.nervous/lein-cljs-lambda "0.6.6"
+(defproject io.nervous/lein-cljs-lambda "0.7.0-SNAPSHOT"
   :description "Deploying Clojurescript functions to AWS Lambda"
   :url "https://github.com/nervous-systems/cljs-lambda"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}
@@ -6,6 +6,8 @@
                  [lein-npm       "0.6.2"]
                  [base64-clj     "0.1.1"]
                  [de.ubercode.clostache/clostache     "1.4.0"]
-                 [org.apache.commons/commons-compress "1.11"]]
+                 [org.apache.commons/commons-compress "1.11"]
+                 [com.amazonaws/aws-java-sdk-lambda   "1.11.132"]
+                 [com.amazonaws/aws-java-sdk-iam      "1.11.132"]]
   :exclusions    [org.clojure/clojure]
   :eval-in-leiningen true)

--- a/plugin/src/leiningen/cljs_lambda.clj
+++ b/plugin/src/leiningen/cljs_lambda.clj
@@ -69,7 +69,7 @@
 
 (def fn-keys
   #{:name :create :region :memory-size :role :invoke :description :timeout
-    :publish :alias :runtime})
+    :publish :alias :runtime :tracing :dead-letter :kms-key})
 
 (defn- augment-fn [{:keys [defaults]} cli-kws fn-spec]
   (merge default-defaults
@@ -189,11 +189,12 @@
 
 (defn default-iam-role
   "Install a Lambda-compatible IAM role, and stick it in project.clj"
-  [{:keys [:cljs-lambda] :as project}]
+  [{:keys [cljs-lambda] :as project}]
   (let [arn (aws/install-iam-role!
-             :cljs-lambda-default
-             (slurp (io/resource "default-iam-role.json"))
-             (slurp (io/resource "default-iam-policy.json")))]
+             (assoc cljs-lambda
+               :role-name :cljs-lambda-default
+               :role      (slurp (io/resource "default-iam-role.json"))
+               :policy    (slurp (io/resource "default-iam-policy.json"))))]
     (println arn)
     (change/change project [:cljs-lambda :defaults]
                    (fn [m & _] (assoc m :role arn)))))


### PR DESCRIPTION
@zrzka This is published as 0.7.0-SNAPSHOT.  Note that it requires leiningen 2.7.2-SNAPSHOT - which is awkward enough to install that release will have to wait until 2.7.2 - unless there's some way to override Leiningen's (unused) Jackson dependency, so it doesn't conflict with the AWS SDK's - but I don't think there is, because of differences between plugins and projects.

I'll leave this open until then, let me know if you encounter any issues - it should operate identically to the existing project.