### PR TITLE
implement callbackWaitsForEmptyEventLoop

### DIFF
--- a/cljs-lambda/src-deps/cljs_lambda/externs/context.js
+++ b/cljs-lambda/src-deps/cljs_lambda/externs/context.js
@@ -5,6 +5,7 @@ context.clientContext;
 context.logGroupName;
 context.logStreamName;
 context.functionName;
+context.callbackWaitsForEmptyEventLoop;
 
 context.getMemoryLimitInMB = function() {};
 context.getFunctionName = function() {};

--- a/cljs-lambda/src/cljs_lambda/context.cljs
+++ b/cljs-lambda/src/cljs_lambda/context.cljs
@@ -26,7 +26,17 @@
    associated with this context.")
   (environment
     [this]
-    "Retrieve a map of environment variables."))
+    "Retrieve a map of environment variables.")
+  (callback-waits?
+    [this]
+    "By default, the callback will wait until the Node.js runtime event loop is
+    empty before freezing the process and returning the results to the caller.
+    You can set this property to false to request AWS Lambda to freeze the
+    process soon after the callback is called, even if there are events in the
+    event loop.")
+  (set-callback-waits
+    [this tf]
+    "Set the callback-waits"))
 
 (defrecord ^:no-doc LambdaContext [js-handle]
   ContextHandle
@@ -35,7 +45,20 @@
   (msecs-remaining [this]
     (.getRemainingTimeInMillis js-handle))
   (environment [this]
-    (json->edn js/process.env)))
+    (json->edn js/process.env))
+  (callback-waits? [this]
+    (.-callbackWaitsForEmptyEventLoop js-handle))
+  (set-callback-waits [this tf]
+    (set! (.-callbackWaitsForEmptyEventLoop js-handle) tf)))
+
+(defn waits?
+  [ctx]
+  (prn ctx)
+  (callback-waits? ctx))
+
+(defn set-waits
+  [ctx tf]
+  (set-callback-waits ctx tf))
 
 (defn env
   "Retrieve an environment variable by name, defaulting to `nil` if not found.

--- a/cljs-lambda/src/cljs_lambda/context.cljs
+++ b/cljs-lambda/src/cljs_lambda/context.cljs
@@ -27,14 +27,14 @@
   (environment
     [this]
     "Retrieve a map of environment variables.")
-  (callback-waits?
+  (waits?
     [this]
     "By default, the callback will wait until the Node.js runtime event loop is
     empty before freezing the process and returning the results to the caller.
     You can set this property to false to request AWS Lambda to freeze the
     process soon after the callback is called, even if there are events in the
     event loop.")
-  (set-callback-waits
+  (set-wait!
     [this tf]
     "Set the callback-waits"))
 
@@ -46,19 +46,20 @@
     (.getRemainingTimeInMillis js-handle))
   (environment [this]
     (json->edn js/process.env))
-  (callback-waits? [this]
+  (waits? [this]
     (.-callbackWaitsForEmptyEventLoop js-handle))
-  (set-callback-waits [this tf]
+  (set-wait! [this tf]
     (set! (.-callbackWaitsForEmptyEventLoop js-handle) tf)))
 
-(defn waits?
+(defn waits-on-event-loop?
   [ctx]
-  (prn ctx)
-  (callback-waits? ctx))
+  "Returns state of context property callbackWaitsForEmptyEventLoop"
+  (waits? ctx))
 
-(defn set-waits
+(defn set-wait-on-event-loop!
+  "Set the context property callbackWaitsForEmptyEventLoop"
   [ctx tf]
-  (set-callback-waits ctx tf))
+  (set-wait! ctx tf))
 
 (defn env
   "Retrieve an environment variable by name, defaulting to `nil` if not found.

--- a/cljs-lambda/src/cljs_lambda/local.cljs
+++ b/cljs-lambda/src/cljs_lambda/local.cljs
@@ -16,7 +16,11 @@
   (msecs-remaining [this]
     -1)
   (environment [this]
-    env))
+    env)
+  (callback-waits? [this]
+    true)
+  (set-callback-waits [this tf]
+    tf))
 
 (defn- stringify-keys
   "Shallowly un-keyword/un-symbol the keys in m"

--- a/cljs-lambda/src/cljs_lambda/local.cljs
+++ b/cljs-lambda/src/cljs_lambda/local.cljs
@@ -17,9 +17,9 @@
     -1)
   (environment [this]
     env)
-  (callback-waits? [this]
+  (waits? [this]
     true)
-  (set-callback-waits [this tf]
+  (set-wait! [this tf]
     tf))
 
 (defn- stringify-keys

--- a/cljs-lambda/test/cljs_lambda/test/util.cljs
+++ b/cljs-lambda/test/cljs_lambda/test/util.cljs
@@ -143,3 +143,21 @@
         ctx (local/->context {:env {'ENV_VAR "deftest-async env"}})]
     (p/then (invoke f nil ctx)
       (will= "deftest-async env"))))
+
+(deftest-async
+  waits
+  (let [f (lambda/async-lambda-fn
+            (fn [_ ctx]
+              (ctx/waits? ctx)))]
+    (p/then
+      (invoke f)
+      (will= true))))
+
+(deftest-async
+  set-waits
+  (let [f (lambda/async-lambda-fn
+            (fn [_ ctx]
+              (ctx/set-waits ctx false)))]
+    (p/then
+      (invoke f)
+      (will= false))))

--- a/cljs-lambda/test/cljs_lambda/test/util.cljs
+++ b/cljs-lambda/test/cljs_lambda/test/util.cljs
@@ -148,7 +148,7 @@
   waits
   (let [f (lambda/async-lambda-fn
             (fn [_ ctx]
-              (ctx/waits? ctx)))]
+              (ctx/waits-on-event-loop? ctx)))]
     (p/then
       (invoke f)
       (will= true))))
@@ -157,7 +157,7 @@
   set-waits
   (let [f (lambda/async-lambda-fn
             (fn [_ ctx]
-              (ctx/set-waits ctx false)))]
+              (ctx/set-wait-on-event-loop! ctx false)))]
     (p/then
       (invoke f)
       (will= false))))


### PR DESCRIPTION
per https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html

## The Context Object Properties (Node.js)

The context object provides the following property that you can update:

**callbackWaitsForEmptyEventLoop**

 > The default value is true. This property is useful only to modify the default behavior of the callback. By default, the callback will wait until the Node.js runtime event loop is empty before freezing the process and returning the results to the caller. You can set this property to false to request AWS Lambda to freeze the process soon after the callback is called, even if there are events in the event loop. AWS Lambda will freeze the process, any state data and the events in the Node.js event loop (any remaining events in the event loop processed when the Lambda function is called next and if AWS Lambda chooses to use the frozen process). For more information about callback, see Using the Callback Parameter.