### PR TITLE
Address #88 by bumping versions in template project.clj

### DIFF
--- a/templates/serverless/src/leiningen/new/serverless_cljs/project.clj
+++ b/templates/serverless/src/leiningen/new/serverless_cljs/project.clj
@@ -1,6 +1,6 @@
 (defproject {{name}} "0.1.0-SNAPSHOT"
-  :dependencies [[org.clojure/clojure       "1.8.0"]
-                 [org.clojure/clojurescript "1.8.51"]
+  :dependencies [[org.clojure/clojure       "1.9.0"]
+                 [org.clojure/clojurescript "1.10.312"]
                  [io.nervous/cljs-lambda    "0.3.5"]]
   :plugins [[lein-npm                    "0.6.2"]
             [io.nervous/lein-cljs-lambda "0.6.6"]]
@@ -11,4 +11,4 @@
                            :output-dir    "target/{{name}}"
                            :target        :nodejs
                            :language-in   :ecmascript5
-                           :optimizations :none}}})
+                           :optimizations :simple}}})


### PR DESCRIPTION
The current configuration in the template doesn't work with more recent versions of Clojurescript. Bump versions and add config to allow it to run.